### PR TITLE
Add navigation cleanup logic

### DIFF
--- a/src/modules/url-manager.ts
+++ b/src/modules/url-manager.ts
@@ -36,6 +36,10 @@ export class UrlManager {
     this.pageViewHandler.updateUrl(url);
   }
 
+  cleanup(): void {
+    this.pageViewHandler.cleanup();
+  }
+
   isRouteExcluded(url: string): boolean {
     return PageViewHandler.isRouteExcluded(url, this.config.excludedUrlPaths || []);
   }

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -323,6 +323,7 @@ export class Tracking {
     try {
       this.sessionManager?.endSession('page_unload');
       this.forceImmediateSendSync();
+      this.urlManager?.cleanup();
       this.trackingManager?.cleanup();
       this.sessionManager?.cleanup();
       this.eventManager?.cleanup();


### PR DESCRIPTION
## Summary
- keep original history callbacks for SPA navigation and restore them during cleanup
- remove empty setTimeout from navigation handler
- expose cleanup in UrlManager and invoke from Tracking.cleanup

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6875fefc0f8c8323b5a9d27e2e0ba1db