### PR TITLE
Fix global metadata sanitization

### DIFF
--- a/src/modules/session-manager.ts
+++ b/src/modules/session-manager.ts
@@ -170,13 +170,13 @@ export class SessionManager {
 
   private validateGlobalMetadata(): void {
     if (Object.keys(this.config?.globalMetadata || {}).length > 0) {
-      const { valid, error } = isValidMetadata('globalMetadata', this.config!.globalMetadata || {});
+      const validationResult = isValidMetadata('globalMetadata', this.config!.globalMetadata || {});
 
-      if (valid) {
-        this.globalMetadata = this.config!.globalMetadata;
+      if (validationResult.valid) {
+        this.globalMetadata = validationResult.sanitizedMetadata;
       } else if (this.isQaMode()) {
         console.error(
-          `TraceLog error: globalMetadata object validation failed (${error || 'unknown error'}). Please, review your data and try again.`,
+          `TraceLog error: globalMetadata object validation failed (${validationResult.error || 'unknown error'}). Please, review your data and try again.`,
         );
       }
     }


### PR DESCRIPTION
## Summary
- store sanitized global metadata after validation

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Playwright server kept running, but tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68762efee5648323a694a19901f605a1