### PR TITLE
Fix session logging on excluded routes

### DIFF
--- a/src/modules/event-manager.ts
+++ b/src/modules/event-manager.ts
@@ -148,6 +148,12 @@ export class EventManager {
     this.eventsQueue = [];
   }
 
+  logTransition(data: { from: string; to: string; type: string }): void {
+    if (this.isQaMode()) {
+      console.log('[TraceLog] navigation transition:', JSON.stringify(data));
+    }
+  }
+
   private sendEvent(payload: EventData): void {
     if (this.isQaMode()) {
       console.log(`[TraceLog] ${payload.type} event:`, JSON.stringify(payload));

--- a/src/modules/event-manager.ts
+++ b/src/modules/event-manager.ts
@@ -91,18 +91,19 @@ export class EventManager {
     }
 
     const isFirstEvent = evType === EventType.SESSION_START;
+    const removePageUrl = isRouteExcluded && isSessionEvent;
 
     const payload: EventData = {
       type: evType,
-      page_url: eventUrl,
+      page_url: removePageUrl ? '' : eventUrl,
       timestamp: Date.now() as Timestamp,
       ...(isFirstEvent && { referrer: document.referrer || 'Direct' }),
-      ...(fromUrl && { from_page_url: fromUrl }),
+      ...(fromUrl && !removePageUrl && { from_page_url: fromUrl }),
       ...(scrollData && { scroll_data: scrollData }),
       ...(clickData && { click_data: clickData }),
       ...(customEvent && { custom_event: customEvent }),
       ...(isFirstEvent && this.utmParams && { utm: this.utmParams }),
-      ...(isRouteExcluded && isSessionEvent && { excluded_route: true }),
+      ...(removePageUrl && { excluded_route: true }),
     };
 
     // Tags functionality enabled

--- a/src/modules/url-manager.ts
+++ b/src/modules/url-manager.ts
@@ -7,6 +7,7 @@ export class UrlManager {
   constructor(
     private readonly config: Config,
     private readonly sendPageViewEvent: (fromUrl: string, toUrl: string, referrer?: string, utm?: any) => void,
+    private readonly notifyNavigation: (data: NavigationData) => void,
     private readonly suppressNextScrollEvent?: () => void,
   ) {
     const pageViewConfig: PageViewConfig = {
@@ -45,6 +46,8 @@ export class UrlManager {
   }
 
   private handleNavigation(data: NavigationData): void {
+    this.notifyNavigation(data);
+
     if (!this.isRouteExcluded(data.toUrl)) {
       this.sendPageViewEvent(data.fromUrl, data.toUrl, data.referrer, data.utm);
     }


### PR DESCRIPTION
## Summary
- avoid storing the page URL when a session starts or ends on an excluded path

## Testing
- `npm run check`
- `npm run test:e2e` *(fails: Command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687d1a8d9b7483239ffa3af22bd6abb7