### PR TITLE
Validate customApiUrl protocol

### DIFF
--- a/src/config/config-loaders.ts
+++ b/src/config/config-loaders.ts
@@ -3,6 +3,7 @@ import { DEFAULT_TRACKING_API_CONFIG } from '../constants';
 import { CONFIG_CONSTANTS } from './config-constants';
 import { IConfigValidator } from './config-validator';
 import { IConfigFetcher, IErrorReporter } from './config-fetcher';
+import { isValidUrl } from '../utils';
 
 export abstract class ConfigLoader {
   abstract load(id: string, config: AppConfig): Promise<Config>;
@@ -101,7 +102,9 @@ export class CustomApiConfigLoader extends ConfigLoader {
     if (corrected.customApiUrl) {
       try {
         const url = new URL(corrected.customApiUrl);
-        corrected.customApiUrl = url.href.replace(/\/$/, '');
+        const sanitized = url.href.replace(/\/$/, '');
+
+        corrected.customApiUrl = isValidUrl(sanitized, url.hostname, corrected.allowHttp) ? sanitized : undefined;
       } catch {
         corrected.customApiUrl = undefined;
       }

--- a/src/modules/config-manager.ts
+++ b/src/modules/config-manager.ts
@@ -46,8 +46,14 @@ export class ConfigManager {
   getApiUrl(): string | undefined {
     if (this.config.customApiUrl) {
       try {
-        new URL(this.config.customApiUrl);
-        return this.config.customApiUrl;
+        const url = new URL(this.config.customApiUrl);
+        const sanitized = url.href.replace(/\/$/, '');
+
+        if (isValidUrl(sanitized, url.hostname, this.config.allowHttp)) {
+          return sanitized;
+        }
+
+        return undefined;
       } catch {
         return undefined;
       }


### PR DESCRIPTION
## Summary
- ensure customApiUrl respects protocol and allowHttp
- sanitize customApiUrl in ConfigManager and ConfigLoader

## Testing
- `npm run check`
- `npm run test:e2e` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e47c2808c83239d536191ec18b1f8