### PR TITLE
Flatten api config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ TraceLog.init({
 // With static config
 TraceLog.init({
   customApiUrl: 'https://analytics.example.com/tracelog',
-  apiConfig: {
-    samplingRate: 1,
-    excludedUrlPaths: ['/admin']
-  }
+  samplingRate: 1,
+  excludedUrlPaths: ['/admin']
 });
 
 TraceLog.event('button_click', { buttonId: 'subscribe-btn' });

--- a/README.md
+++ b/README.md
@@ -50,18 +50,18 @@ import { TraceLog } from '@tracelog/client';
 
 // Basic setup - events go to your API
 TraceLog.init({
-  customApiUrl: 'https://analytics.example.com/tracelog'
+  apiUrl: 'https://analytics.example.com/tracelog'
 });
 
 // With remote config from your backend
 TraceLog.init({
-  customApiUrl: 'https://analytics.example.com/tracelog',
-  customApiConfigUrl: 'https://analytics.example.com/config'
+  apiUrl: 'https://analytics.example.com/tracelog',
+  remoteConfigApiUrl: 'https://analytics.example.com/config'
 });
 
 // With static config
 TraceLog.init({
-  customApiUrl: 'https://analytics.example.com/tracelog',
+  apiUrl: 'https://analytics.example.com/tracelog',
   samplingRate: 1,
   excludedUrlPaths: ['/admin']
 });
@@ -73,8 +73,8 @@ TraceLog.event('button_click', { buttonId: 'subscribe-btn' });
 
 **Self-hosted mode:**
 - ❌ Don't use `id` field (causes error)
-- ✅ `customApiUrl` is required
-- ⚠️ `customApiConfigUrl` only works with `customApiUrl`
+- ✅ `apiUrl` is required
+- ⚠️ `remoteConfigApiUrl` only works with `apiUrl`
 
 **Both modes:**
 - ⚠️ `TraceLog.init()` can only be called once
@@ -83,7 +83,7 @@ TraceLog.event('button_click', { buttonId: 'subscribe-btn' });
 
 ### Troubleshooting
 - **CORS errors**: Add `Access-Control-Allow-Origin` headers to your server
-- **Config errors**: Ensure `customApiConfigUrl` returns valid JSON  
+- **Config errors**: Ensure `remoteConfigApiUrl` returns valid JSON
 - **HTTPS blocked**: Set `allowHttp: true` for development endpoints
 
 ---

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,20 +20,20 @@ export const init = (config: AppConfig): void => {
     return;
   }
 
-  const usingCustomServer = Boolean(config?.customApiUrl || config?.customApiConfigUrl);
+  const usingCustomServer = Boolean(config?.apiUrl || config?.remoteConfigApiUrl);
 
   if (usingCustomServer && config?.id) {
-    logError('Invalid configuration: id cannot be used with customApiUrl and/or customApiConfigUrl');
+    logError('Invalid configuration: id cannot be used with apiUrl and/or remoteConfigApiUrl');
     return;
   }
 
   if (!usingCustomServer && !config?.id) {
-    logError('Tracking ID is required when customApiUrl is not provided');
+    logError('Tracking ID is required when apiUrl is not provided');
     return;
   }
 
-  if (config?.customApiConfigUrl && !config?.customApiUrl) {
-    logError('customApiConfigUrl requires customApiUrl to be set');
+  if (config?.remoteConfigApiUrl && !config?.apiUrl) {
+    logError('remoteConfigApiUrl requires apiUrl to be set');
     return;
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,10 +20,10 @@ export const init = (config: Config): void => {
     return;
   }
 
-  const usingCustomServer = Boolean(config?.apiUrl || config?.remoteConfigApiUrl);
+  const usingCustomServer = Boolean(config?.apiUrl ?? config?.remoteConfigApiUrl);
 
   if (usingCustomServer && config?.id) {
-    logError('Invalid configuration: id cannot be used with apiUrl and/or remoteConfigApiUrl');
+    logError('Invalid configuration: id cannot be used with apiUrl or remoteConfigApiUrl');
     return;
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { Tracking } from './tracking';
-import { AppConfig, MetadataType } from './types';
+import { Config, MetadataType } from './types';
 import { logError } from './utils';
 
 export * as Types from './types';
@@ -11,7 +11,7 @@ let trackingInstance: Tracking | undefined;
  * @param id - Tracking ID
  * @param config - Optional configuration
  */
-export const init = (config: AppConfig): void => {
+export const init = (config: Config): void => {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
     return;
   }

--- a/src/config/config-fetcher.ts
+++ b/src/config/config-fetcher.ts
@@ -82,10 +82,10 @@ export class ConfigFetcher extends Base implements IConfigFetcher {
   }
 
   private buildConfigUrl(config: AppConfig): string | undefined {
-    // Handle custom API config URL
-    if (config.customApiConfigUrl) {
+    // Handle remote config URL
+    if (config.remoteConfigApiUrl) {
       try {
-        const url = new URL(config.customApiConfigUrl);
+        const url = new URL(config.remoteConfigApiUrl);
         return url.href.replace(/\/$/, '');
       } catch {
         return undefined;
@@ -93,9 +93,9 @@ export class ConfigFetcher extends Base implements IConfigFetcher {
     }
 
     // Handle custom API URL (derive config URL from it)
-    if (config.customApiUrl) {
+    if (config.apiUrl) {
       try {
-        const url = new URL(config.customApiUrl);
+        const url = new URL(config.apiUrl);
         return `${url.origin}${url.pathname.replace(/\/$/, '')}/config`;
       } catch {
         return undefined;

--- a/src/config/config-fetcher.ts
+++ b/src/config/config-fetcher.ts
@@ -1,4 +1,4 @@
-import { AppConfig, ApiConfig } from '../types';
+import { Config, ApiConfig } from '../types';
 import { sanitizeApiConfig, isValidUrl, buildDynamicApiUrl } from '../utils';
 import { DEFAULT_TRACKING_API_CONFIG, FETCH_TIMEOUT_MS, MAX_FETCH_ATTEMPTS } from '../constants';
 import { VERSION } from '../version';
@@ -6,7 +6,7 @@ import { IRateLimiter } from './rate-limiter';
 import { Base } from '../base';
 
 export interface IConfigFetcher {
-  fetch(config: AppConfig): Promise<ApiConfig | undefined>;
+  fetch(config: Config): Promise<ApiConfig | undefined>;
 }
 
 export class ConfigFetcher extends Base implements IConfigFetcher {
@@ -14,7 +14,7 @@ export class ConfigFetcher extends Base implements IConfigFetcher {
     super();
   }
 
-  async fetch(config: AppConfig): Promise<ApiConfig | undefined> {
+  async fetch(config: Config): Promise<ApiConfig | undefined> {
     if (!this.rateLimiter.canFetch()) {
       if (this.rateLimiter.hasExceededMaxAttempts()) {
         this.log('error', `Max fetch attempts exceeded (${MAX_FETCH_ATTEMPTS})`);
@@ -33,7 +33,7 @@ export class ConfigFetcher extends Base implements IConfigFetcher {
     }
   }
 
-  private async performFetch(config: AppConfig): Promise<ApiConfig | undefined> {
+  private async performFetch(config: Config): Promise<ApiConfig | undefined> {
     const configUrl = this.buildConfigUrl(config);
 
     if (!configUrl) {
@@ -81,7 +81,7 @@ export class ConfigFetcher extends Base implements IConfigFetcher {
     }
   }
 
-  private buildConfigUrl(config: AppConfig): string | undefined {
+  private buildConfigUrl(config: Config): string | undefined {
     // Handle remote config URL
     if (config.remoteConfigApiUrl) {
       try {

--- a/src/config/config-loaders.ts
+++ b/src/config/config-loaders.ts
@@ -11,12 +11,9 @@ export abstract class ConfigLoader {
 
 export class DemoConfigLoader extends ConfigLoader {
   async load(config: AppConfig): Promise<Config> {
-    const { apiConfig = {}, ...rest } = config;
-
     return {
       ...DEFAULT_TRACKING_API_CONFIG,
-      ...apiConfig,
-      ...rest,
+      ...config,
       qaMode: true,
       samplingRate: 1,
       tags: [],
@@ -34,12 +31,11 @@ export class CustomApiConfigLoader extends Base implements ConfigLoader {
   }
 
   async load(config: AppConfig): Promise<Config> {
-    const { apiConfig = {}, customApiConfigUrl, ...rest } = config;
+    const { customApiConfigUrl } = config;
 
     let merged: Config = {
       ...DEFAULT_TRACKING_API_CONFIG,
-      ...apiConfig,
-      ...rest,
+      ...config,
     };
 
     await this.validateAndReport(config);
@@ -126,11 +122,9 @@ export class StandardConfigLoader extends Base implements ConfigLoader {
     const errors: string[] = [];
     const warnings: string[] = [];
 
-    const { apiConfig = {}, ...rest } = config;
     let finalConfig: Config = {
       ...DEFAULT_TRACKING_API_CONFIG,
-      ...apiConfig,
-      ...rest,
+      ...config,
     };
 
     try {

--- a/src/config/config-loaders.ts
+++ b/src/config/config-loaders.ts
@@ -1,4 +1,4 @@
-import { AppConfig, Config } from '../types';
+import { Config } from '../types';
 import { DEFAULT_TRACKING_API_CONFIG, SESSION_TIMEOUT_DEFAULT_MS, SESSION_TIMEOUT_MIN_MS } from '../constants';
 import { IConfigValidator } from './config-validator';
 import { IConfigFetcher } from './config-fetcher';
@@ -6,11 +6,11 @@ import { isValidUrl } from '../utils';
 import { Base } from '../base';
 
 export abstract class ConfigLoader {
-  abstract load(config: AppConfig): Promise<Config>;
+  abstract load(config: Config): Promise<Config>;
 }
 
 export class DemoConfigLoader extends ConfigLoader {
-  async load(config: AppConfig): Promise<Config> {
+  async load(config: Config): Promise<Config> {
     return {
       ...DEFAULT_TRACKING_API_CONFIG,
       ...config,
@@ -30,7 +30,7 @@ export class CustomApiConfigLoader extends Base implements ConfigLoader {
     super();
   }
 
-  async load(config: AppConfig): Promise<Config> {
+  async load(config: Config): Promise<Config> {
     const { remoteConfigApiUrl } = config;
 
     let merged: Config = {
@@ -55,7 +55,7 @@ export class CustomApiConfigLoader extends Base implements ConfigLoader {
     return this.applyCorrections(merged);
   }
 
-  private async validateAndReport(config: AppConfig): Promise<void> {
+  private async validateAndReport(config: Config): Promise<void> {
     const result = this.validator.validate(config);
 
     if (result.errors.length > 0) {
@@ -114,7 +114,7 @@ export class StandardConfigLoader extends Base implements ConfigLoader {
     super();
   }
 
-  async load(config: AppConfig): Promise<Config> {
+  async load(config: Config): Promise<Config> {
     if (!config.id) {
       throw new Error('Tracking ID is required when not using apiUrl');
     }
@@ -186,7 +186,7 @@ export class ConfigLoaderFactory extends Base {
     super();
   }
 
-  createLoader(config: AppConfig): ConfigLoader {
+  createLoader(config: Config): ConfigLoader {
     if (config.id === 'demo') {
       return new DemoConfigLoader();
     }

--- a/src/config/config-loaders.ts
+++ b/src/config/config-loaders.ts
@@ -31,7 +31,7 @@ export class CustomApiConfigLoader extends Base implements ConfigLoader {
   }
 
   async load(config: AppConfig): Promise<Config> {
-    const { customApiConfigUrl } = config;
+    const { remoteConfigApiUrl } = config;
 
     let merged: Config = {
       ...DEFAULT_TRACKING_API_CONFIG,
@@ -40,7 +40,7 @@ export class CustomApiConfigLoader extends Base implements ConfigLoader {
 
     await this.validateAndReport(config);
 
-    if (customApiConfigUrl) {
+    if (remoteConfigApiUrl) {
       try {
         const remote = await this.fetcher.fetch(config);
 
@@ -82,23 +82,23 @@ export class CustomApiConfigLoader extends Base implements ConfigLoader {
       corrected.sessionTimeout = SESSION_TIMEOUT_DEFAULT_MS;
     }
 
-    if (corrected.customApiUrl) {
+    if (corrected.apiUrl) {
       try {
-        const url = new URL(corrected.customApiUrl);
+        const url = new URL(corrected.apiUrl);
         const sanitized = url.href.replace(/\/$/, '');
 
-        corrected.customApiUrl = isValidUrl(sanitized, url.hostname, corrected.allowHttp) ? sanitized : undefined;
+        corrected.apiUrl = isValidUrl(sanitized, url.hostname, corrected.allowHttp) ? sanitized : undefined;
       } catch {
-        corrected.customApiUrl = undefined;
+        corrected.apiUrl = undefined;
       }
     }
 
-    if (corrected.customApiConfigUrl) {
+    if (corrected.remoteConfigApiUrl) {
       try {
-        const url = new URL(corrected.customApiConfigUrl);
-        corrected.customApiConfigUrl = url.href.replace(/\/$/, '');
+        const url = new URL(corrected.remoteConfigApiUrl);
+        corrected.remoteConfigApiUrl = url.href.replace(/\/$/, '');
       } catch {
-        corrected.customApiConfigUrl = undefined;
+        corrected.remoteConfigApiUrl = undefined;
       }
     }
 
@@ -116,7 +116,7 @@ export class StandardConfigLoader extends Base implements ConfigLoader {
 
   async load(config: AppConfig): Promise<Config> {
     if (!config.id) {
-      throw new Error('Tracking ID is required when not using customApiUrl');
+      throw new Error('Tracking ID is required when not using apiUrl');
     }
 
     const errors: string[] = [];
@@ -191,7 +191,7 @@ export class ConfigLoaderFactory extends Base {
       return new DemoConfigLoader();
     }
 
-    if (config.customApiUrl) {
+    if (config.apiUrl) {
       return new CustomApiConfigLoader(this.validator, this.fetcher);
     }
 

--- a/src/config/config-validator.ts
+++ b/src/config/config-validator.ts
@@ -1,8 +1,8 @@
-import { AppConfig } from '../types';
-import { validateAppConfig } from '../utils';
+import { Config } from '../types';
+import { validateConfig } from '../utils';
 
 export interface IConfigValidator {
-  validate(config: AppConfig): ValidationResult;
+  validate(config: Config): ValidationResult;
 }
 
 export interface ValidationResult {
@@ -12,9 +12,9 @@ export interface ValidationResult {
 }
 
 export class ConfigValidator implements IConfigValidator {
-  validate(config: AppConfig): ValidationResult {
+  validate(config: Config): ValidationResult {
     try {
-      const result = validateAppConfig(config);
+      const result = validateConfig(config);
 
       return {
         errors: result.errors,
@@ -30,7 +30,7 @@ export class ConfigValidator implements IConfigValidator {
     }
   }
 
-  validateAndReport(config: AppConfig, reportCallback: (result: ValidationResult) => void): ValidationResult {
+  validateAndReport(config: Config, reportCallback: (result: ValidationResult) => void): ValidationResult {
     const result = this.validate(config);
     reportCallback(result);
     return result;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { ApiConfig, AppConfig } from './types';
+import { ApiConfig, Config } from './types';
 
 // Performance constants
 export const MAX_FETCH_ATTEMPTS = 3;
@@ -38,7 +38,7 @@ export const DEFAULT_TRACKING_API_CONFIG: ApiConfig = {
 };
 
 // Default tracking app config
-export const DEFAULT_TRACKING_APP_CONFIG: AppConfig = {
+export const DEFAULT_TRACKING_APP_CONFIG: Config = {
   sessionTimeout: SESSION_TIMEOUT_DEFAULT_MS,
   allowHttp: false,
 };

--- a/src/modules/config-manager.ts
+++ b/src/modules/config-manager.ts
@@ -37,9 +37,9 @@ export class ConfigManager extends Base {
   }
 
   getApiUrl(): string | undefined {
-    if (this.config.customApiUrl) {
+    if (this.config.apiUrl) {
       try {
-        const url = new URL(this.config.customApiUrl);
+        const url = new URL(this.config.apiUrl);
         const sanitized = url.href.replace(/\/$/, '');
 
         if (isValidUrl(sanitized, url.hostname, this.config.allowHttp)) {
@@ -96,7 +96,7 @@ export class ConfigManager extends Base {
       issues.push('Max fetch attempts exceeded');
     }
 
-    if (!this.id && !this.config.customApiUrl) {
+    if (!this.id && !this.config.apiUrl) {
       issues.push('Missing configuration ID');
     }
 

--- a/src/modules/config-manager.ts
+++ b/src/modules/config-manager.ts
@@ -1,4 +1,4 @@
-import { AppConfig, Config } from '../types';
+import { Config } from '../types';
 import { DEFAULT_TRACKING_API_CONFIG, DEFAULT_TRACKING_APP_CONFIG } from '../constants';
 import { isValidUrl, buildDynamicApiUrl } from '../utils';
 import { ConfigValidator, RateLimiter, ConfigFetcher, ConfigLoaderFactory } from '../config';
@@ -22,7 +22,7 @@ export class ConfigManager extends Base {
     this.loaderFactory = new ConfigLoaderFactory(this.validator, this.fetcher);
   }
 
-  async loadConfig(config: AppConfig): Promise<Config> {
+  async loadConfig(config: Config): Promise<Config> {
     this.id = config.id ?? '';
 
     const loader = this.loaderFactory.createLoader(config);

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,5 +1,5 @@
 import { ConfigManager, SessionManager, EventManager, TrackingManager, DataSender, UrlManager } from './modules';
-import { AppConfig, EventType, MetadataType, EventHandler, DeviceType } from './types';
+import { Config, EventType, MetadataType, EventHandler, DeviceType } from './types';
 import { NavigationData } from './events';
 import { Base } from './base';
 
@@ -33,7 +33,7 @@ export class Tracking extends Base {
   private dataSender!: DataSender;
   private urlManager!: UrlManager;
 
-  constructor(config: AppConfig) {
+  constructor(config: Config) {
     super();
 
     this.initializationPromise = this.initializeTracking(config).catch((error) => {
@@ -41,7 +41,7 @@ export class Tracking extends Base {
     });
   }
 
-  private async initializeTracking(config: AppConfig): Promise<void> {
+  private async initializeTracking(config: Config): Promise<void> {
     if (this.initializationState !== InitializationState.UNINITIALIZED) {
       return this.initializationPromise;
     }
@@ -324,7 +324,7 @@ export class Tracking extends Base {
     this.eventManager.updatePageUrl(url);
   }
 
-  async getConfig(): Promise<AppConfig | undefined> {
+  async getConfig(): Promise<Config | undefined> {
     await this.waitForInitialization();
     return this.configManager?.getConfig();
   }

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -24,9 +24,9 @@ export interface ApiConfig {
   excludedUrlPaths: string[];
 }
 
-export interface AppConfig {
+export interface AppConfig extends ApiConfig {
   /**
-   * Unique project identifier. Required when not using a customApiUrl.
+   * Unique project identifier. Required when not using `apiUrl`.
    */
   id?: string;
   /**
@@ -50,33 +50,13 @@ export interface AppConfig {
    * Custom URL to send tracking events. When set, TraceLog will bypass the
    * default domain generation and use this URL directly.
    */
-  customApiUrl?: string;
+  apiUrl?: string;
   /**
    * When sending events to your own server, specify where to fetch
    * API-level configuration. This allows dynamic updates from your backend.
-   * If omitted, no remote config will be fetched when using `customApiUrl`.
+   * If omitted, no remote config will be fetched when using `apiUrl`.
    */
-  customApiConfigUrl?: string;
-  /**
-   * Enables QA mode for testing and debugging purposes.
-   * When enabled, events may be processed differently for development environments.
-   */
-  qaMode?: boolean;
-  /**
-   * Sampling rate as a percentage (0-1) to control how many events are sent.
-   * A value of 1 means all events are sent, while 0.5 means only half of events are sent.
-   */
-  samplingRate?: number;
-  /**
-   * Array of tag configurations for categorizing and filtering events.
-   * Tags help organize and segment tracking data for analysis.
-   */
-  tags?: TagConfig[];
-  /**
-   * Array of URL path patterns to exclude from tracking.
-   * Events will not be sent for pages matching these patterns.
-   */
-  excludedUrlPaths?: string[];
+  remoteConfigApiUrl?: string;
   /**
    * Allow HTTP requests to be made. This is useful for testing and development.
    */

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -24,7 +24,7 @@ export interface ApiConfig {
   excludedUrlPaths: string[];
 }
 
-export interface AppConfig extends ApiConfig {
+export interface Config extends ApiConfig {
   /**
    * Unique project identifier. Required when not using `apiUrl`.
    */
@@ -62,5 +62,3 @@ export interface AppConfig extends ApiConfig {
    */
   allowHttp?: boolean;
 }
-
-export type Config = ApiConfig & Omit<AppConfig, keyof ApiConfig>;

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -58,14 +58,29 @@ export interface AppConfig {
    */
   customApiConfigUrl?: string;
   /**
-   * Provide API-level configuration when using a custom server. If set,
-   * these values override the defaults and no remote config will be fetched.
+   * Enables QA mode for testing and debugging purposes.
+   * When enabled, events may be processed differently for development environments.
    */
-  apiConfig?: Partial<ApiConfig>;
+  qaMode?: boolean;
+  /**
+   * Sampling rate as a percentage (0-1) to control how many events are sent.
+   * A value of 1 means all events are sent, while 0.5 means only half of events are sent.
+   */
+  samplingRate?: number;
+  /**
+   * Array of tag configurations for categorizing and filtering events.
+   * Tags help organize and segment tracking data for analysis.
+   */
+  tags?: TagConfig[];
+  /**
+   * Array of URL path patterns to exclude from tracking.
+   * Events will not be sent for pages matching these patterns.
+   */
+  excludedUrlPaths?: string[];
   /**
    * Allow HTTP requests to be made. This is useful for testing and development.
    */
   allowHttp?: boolean;
 }
 
-export type Config = ApiConfig & Omit<AppConfig, 'apiConfig'>;
+export type Config = ApiConfig & Omit<AppConfig, keyof ApiConfig>;

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -394,25 +394,17 @@ export const validateAppConfig = (config: AppConfig): { errors: string[]; warnin
   validateUrl(config.customApiUrl, config.allowHttp, 'customApiUrl', errors);
   validateUrl(config.customApiConfigUrl, config.allowHttp, 'customApiConfigUrl', errors);
 
-  if (config.apiConfig !== undefined) {
-    if (typeof config.apiConfig !== 'object' || config.apiConfig === null) {
-      errors.push('apiConfig must be an object');
-    } else {
-      const { samplingRate, qaMode, tags, excludedUrlPaths } = config.apiConfig;
+  validateSamplingRate(config.samplingRate, errors);
 
-      validateSamplingRate(samplingRate, errors);
-
-      if (qaMode !== undefined && typeof qaMode !== 'boolean') {
-        errors.push('apiConfig.qaMode must be a boolean');
-      }
-
-      if (tags !== undefined && !Array.isArray(tags)) {
-        errors.push('apiConfig.tags must be an array');
-      }
-
-      validateExcludedUrlPaths(excludedUrlPaths, errors, 'apiConfig.');
-    }
+  if (config.qaMode !== undefined && typeof config.qaMode !== 'boolean') {
+    errors.push('qaMode must be a boolean');
   }
+
+  if (config.tags !== undefined && !Array.isArray(config.tags)) {
+    errors.push('tags must be an array');
+  }
+
+  validateExcludedUrlPaths(config.excludedUrlPaths, errors);
 
   return { errors, warnings };
 };

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -4,7 +4,7 @@ import {
   MAX_CUSTOM_EVENT_NAME_LENGTH,
   MAX_CUSTOM_EVENT_STRING_SIZE,
 } from '../constants';
-import { EventType, MetadataType, ScrollDirection, EventData, Queue, AppConfig, Config } from '../types';
+import { EventType, MetadataType, ScrollDirection, EventData, Queue, Config } from '../types';
 import { sanitizeMetadata } from './sanitize.utils';
 
 export const isOnlyPrimitiveFields = (object: Record<string, any>): boolean => {
@@ -360,7 +360,7 @@ const validateUrl = (url: unknown, allowHttp: boolean | undefined, fieldName: st
   }
 };
 
-export const validateAppConfig = (config: AppConfig): { errors: string[]; warnings: string[] } => {
+export const validateConfig = (config: Config): { errors: string[]; warnings: string[] } => {
   const errors: string[] = [];
   const warnings: string[] = [];
 

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -339,7 +339,7 @@ const validateExcludedUrlPaths = (excludedUrlPaths: unknown, errors: string[], p
 };
 
 /**
- * Validates a URL field (customApiUrl or customApiConfigUrl)
+ * Validates a URL field (apiUrl or remoteConfigApiUrl)
  */
 const validateUrl = (url: unknown, allowHttp: boolean | undefined, fieldName: string, errors: string[]): void => {
   if (url !== undefined) {
@@ -391,8 +391,8 @@ export const validateAppConfig = (config: AppConfig): { errors: string[]; warnin
   }
 
   // Use helper functions for common validations
-  validateUrl(config.customApiUrl, config.allowHttp, 'customApiUrl', errors);
-  validateUrl(config.customApiConfigUrl, config.allowHttp, 'customApiConfigUrl', errors);
+  validateUrl(config.apiUrl, config.allowHttp, 'apiUrl', errors);
+  validateUrl(config.remoteConfigApiUrl, config.allowHttp, 'remoteConfigApiUrl', errors);
 
   validateSamplingRate(config.samplingRate, errors);
 
@@ -416,8 +416,8 @@ export const validateFinalConfig = (config: Config): { errors: string[]; warning
   // Use helper functions for common validations
   validateSamplingRate(config.samplingRate, errors);
   validateExcludedUrlPaths(config.excludedUrlPaths, errors);
-  validateUrl(config.customApiUrl, config.allowHttp, 'customApiUrl', errors);
-  validateUrl(config.customApiConfigUrl, config.allowHttp, 'customApiConfigUrl', errors);
+  validateUrl(config.apiUrl, config.allowHttp, 'apiUrl', errors);
+  validateUrl(config.remoteConfigApiUrl, config.allowHttp, 'remoteConfigApiUrl', errors);
 
   return { errors, warnings };
 };

--- a/tests/e2e/allow-http.spec.ts
+++ b/tests/e2e/allow-http.spec.ts
@@ -15,6 +15,6 @@ test.describe('Allow HTTP Validation', () => {
     await page.waitForTimeout(500);
 
     expect(consoleErrors).toHaveLength(1);
-    expect(consoleErrors[0]).toBe('[TraceLog] Initialization rejected: Configuration errors: customApiUrl using http requires allowHttp=true');
+    expect(consoleErrors[0]).toBe('[TraceLog] Initialization rejected: Configuration errors: apiUrl using http requires allowHttp=true');
   });
 });

--- a/tests/e2e/api-config.spec.ts
+++ b/tests/e2e/api-config.spec.ts
@@ -49,5 +49,6 @@ test.describe('API Config', () => {
 
     expect(configLog).toContain('"qaMode":true');
     expect(configLog).toContain('"samplingRate":0.33');
+    expect(configLog).toContain('"sessionTimeout":40000');
   });
 });

--- a/tests/e2e/invalid-config.spec.ts
+++ b/tests/e2e/invalid-config.spec.ts
@@ -15,6 +15,6 @@ test.describe('Invalid Configuration', () => {
     await page.waitForTimeout(500);
 
     expect(consoleErrors).toHaveLength(1);
-    expect(consoleErrors[0]).toBe('[TraceLog] Invalid configuration: id cannot be used with apiUrl and/or remoteConfigApiUrl');
+    expect(consoleErrors[0]).toBe('[TraceLog] Invalid configuration: id cannot be used with apiUrl or remoteConfigApiUrl');
   });
 });

--- a/tests/e2e/invalid-config.spec.ts
+++ b/tests/e2e/invalid-config.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Invalid Configuration', () => {
-  test('should log error when id and customApiUrl are used simultaneously', async ({ page }) => {
+  test('should log error when id and apiUrl are used simultaneously', async ({ page }) => {
     const consoleErrors: string[] = [];
 
     page.on('console', (msg) => {
@@ -15,6 +15,6 @@ test.describe('Invalid Configuration', () => {
     await page.waitForTimeout(500);
 
     expect(consoleErrors).toHaveLength(1);
-    expect(consoleErrors[0]).toBe('[TraceLog] Invalid configuration: id cannot be used with customApiUrl and/or customApiConfigUrl');
+    expect(consoleErrors[0]).toBe('[TraceLog] Invalid configuration: id cannot be used with apiUrl and/or remoteConfigApiUrl');
   });
 });

--- a/tests/fixtures/use-cases/client-remote-config.html
+++ b/tests/fixtures/use-cases/client-remote-config.html
@@ -12,6 +12,7 @@
       apiUrl: 'http://localhost:3000/collect',
       remoteConfigApiUrl: 'http://localhost:3000/json/client-remote-config.json',
       allowHttp: true,
+      sessionTimeout: 40_000
     });
   </script>
 </body>

--- a/tests/fixtures/use-cases/client-remote-config.html
+++ b/tests/fixtures/use-cases/client-remote-config.html
@@ -9,8 +9,8 @@
   <script type="module">
     import { TraceLog } from '../tracelog.js';
     TraceLog.init({
-      customApiUrl: 'http://localhost:3000/collect',
-      customApiConfigUrl: 'http://localhost:3000/json/client-remote-config.json',
+      apiUrl: 'http://localhost:3000/collect',
+      remoteConfigApiUrl: 'http://localhost:3000/json/client-remote-config.json',
       allowHttp: true,
     });
   </script>

--- a/tests/fixtures/use-cases/client-static-config.html
+++ b/tests/fixtures/use-cases/client-static-config.html
@@ -10,11 +10,9 @@
     import { TraceLog } from '../tracelog.js';
     TraceLog.init({
       customApiUrl: 'https://analytics.example.com/tracelog',
-      apiConfig: {
-        qaMode: true,
-        samplingRate: 0.7,
-        excludedUrlPaths: ['/admin', '/debug'],
-      }
+      qaMode: true,
+      samplingRate: 0.7,
+      excludedUrlPaths: ['/admin', '/debug'],
     });
   </script>
 </body>

--- a/tests/fixtures/use-cases/client-static-config.html
+++ b/tests/fixtures/use-cases/client-static-config.html
@@ -9,7 +9,7 @@
   <script type="module">
     import { TraceLog } from '../tracelog.js';
     TraceLog.init({
-      customApiUrl: 'https://analytics.example.com/tracelog',
+      apiUrl: 'https://analytics.example.com/tracelog',
       qaMode: true,
       samplingRate: 0.7,
       excludedUrlPaths: ['/admin', '/debug'],

--- a/tests/fixtures/use-cases/http-without-allow.html
+++ b/tests/fixtures/use-cases/http-without-allow.html
@@ -9,7 +9,7 @@
   <script type="module">
     import { TraceLog } from '../tracelog.js';
     TraceLog.init({
-      customApiUrl: 'http://localhost:3000/collect'
+      apiUrl: 'http://localhost:3000/collect'
     });
   </script>
 </body>

--- a/tests/fixtures/use-cases/id-and-custom.html
+++ b/tests/fixtures/use-cases/id-and-custom.html
@@ -10,7 +10,7 @@
     import { TraceLog } from '../tracelog.js';
     TraceLog.init({
       id: 'abc123',
-      customApiUrl: 'https://analytics.example.com/tracelog'
+      apiUrl: 'https://analytics.example.com/tracelog'
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- flatten `apiConfig` options into `AppConfig`
- adjust loaders and validation to use new root properties
- update README and test fixture for new syntax

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6880d2b88dd083238edf0aea090edbb1